### PR TITLE
Adds simple CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,28 @@
+name: CD
+
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+
+jobs:
+  cd:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: trueapierror
+          tags: wellington31/go-demo-application:latest
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+


### PR DESCRIPTION
This workflow just create a new latest docker tag every time is
executed, and the execution is done manually through
`workflow_dispatch`. This CD is just for test purposes.